### PR TITLE
Fix type error

### DIFF
--- a/src/Resources/contao/dca/tl_translation.php
+++ b/src/Resources/contao/dca/tl_translation.php
@@ -101,7 +101,7 @@ $GLOBALS['TL_DCA']['tl_translation'] = [
                 'multiple' => false
             ],
             'filter' => true,
-            'sql' => ['type'=>'string', 'fixed'=>true, 'length' => '1', 'default' => '','notnull' => false]
+            'sql' => ['type'=>'string', 'fixed'=>true, 'length' => 1, 'default' => '','notnull' => false]
         ]
     ]
 ];

--- a/src/Resources/contao/dca/tl_translation.php
+++ b/src/Resources/contao/dca/tl_translation.php
@@ -101,7 +101,7 @@ $GLOBALS['TL_DCA']['tl_translation'] = [
                 'multiple' => false
             ],
             'filter' => true,
-            'sql' => ['type'=>'string', 'fixed'=>true, 'length' => 1, 'default' => '','notnull' => false]
+            'sql' => ['type'=>'string', 'fixed'=>true, 'length' => 1, 'default' => '']
         ]
     ]
 ];


### PR DESCRIPTION
Fixes the following error:

```
Doctrine\DBAL\Schema\Column::setLength(): Argument #1 ($length) must be of type ?int, string given
```

Though I would generally recommend to use

```php
'sql' => ['type' => 'boolean', 'default' => false]
```

instead (but this might require more changes).